### PR TITLE
✨ Add draw rectangle and get counts tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: quarterly
 repos:
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: 'v10.3.0'
+    rev: 'v10.4.1'
     hooks:
       - id: eslint
         additional_dependencies:

--- a/index.html
+++ b/index.html
@@ -276,6 +276,11 @@
 
             <h3>Changelog</h3>
             <ul>
+                <li>
+                <strong>2026-06-11</strong>: Added "Draw to Count" button that allows
+                users to draw a polygon on the map and count the number of LSRs and
+                SBWs that intersect that polygon.
+                </li>
                 <li><strong>2025-07-21</strong>: Added an option to filter LSRs
                 by their magnitude.</li>
                 <li><strong>2025-06-06</strong>: Fixed a bug with sorting of

--- a/index.html
+++ b/index.html
@@ -278,8 +278,8 @@
             <ul>
                 <li>
                 <strong>2026-06-11</strong>: Added "Draw to Count" button that allows
-                users to draw a polygon on the map and count the number of LSRs and
-                SBWs that intersect that polygon.
+                users to draw a rectangle on the map and count the number of
+                visible LSRs and SBWs that intersect that polygon.
                 </li>
                 <li><strong>2025-07-21</strong>: Added an option to filter LSRs
                 by their magnitude.</li>

--- a/src/drawCountManager.js
+++ b/src/drawCountManager.js
@@ -79,13 +79,6 @@ function createStatsElement() {
 function makeStatsElementDraggable(statsElements) {
     let dragState = null;
 
-    const stopDragging = () => {
-        dragState = null;
-        statsElements.element.classList.remove('dragging');
-        document.removeEventListener('mousemove', handleDrag);
-        document.removeEventListener('mouseup', stopDragging);
-    };
-
     const handleDrag = (event) => {
         if (!dragState) {
             return;
@@ -96,6 +89,14 @@ function makeStatsElementDraggable(statsElements) {
         statsElements.element.style.left = `${Math.max(10, nextLeft)}px`;
         statsElements.element.style.top = `${Math.max(10, nextTop)}px`;
     };
+
+    const stopDragging = () => {
+        dragState = null;
+        statsElements.element.classList.remove('dragging');
+        document.removeEventListener('mousemove', handleDrag);
+        document.removeEventListener('mouseup', stopDragging);
+    };
+
 
     statsElements.header.addEventListener('mousedown', (event) => {
         if (event.target === statsElements.closeButton) {

--- a/src/drawCountManager.js
+++ b/src/drawCountManager.js
@@ -1,0 +1,304 @@
+import DragBox from 'ol/interaction/DragBox';
+import { always } from 'ol/events/condition';
+import Feature from 'ol/Feature';
+import { fromExtent } from 'ol/geom/Polygon';
+import VectorSource from 'ol/source/Vector';
+import VectorLayer from 'ol/layer/Vector';
+import Style from 'ol/style/Style';
+import Fill from 'ol/style/Fill';
+import Stroke from 'ol/style/Stroke';
+import { transformExtent } from 'ol/proj';
+import { getLSRLayer, getSBWLayer } from './layerManager.js';
+import { summarizeDrawCounts, formatTypeCounts, formatTypeCountText } from './drawCountUtils.js';
+
+function makeSelectionLayer() {
+    return new VectorLayer({
+        source: new VectorSource(),
+        style: new Style({
+            fill: new Fill({ color: 'rgba(33, 150, 243, 0.2)' }),
+            stroke: new Stroke({ color: '#0d47a1', width: 2 })
+        }),
+        zIndex: 2000
+    });
+}
+
+function createStatsElement() {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'draw-count-stats';
+
+    const header = document.createElement('div');
+    header.className = 'draw-count-stats-header';
+
+    const title = document.createElement('span');
+    title.textContent = 'Selection Counts';
+
+    const closeButton = document.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = 'draw-count-stats-close';
+    closeButton.setAttribute('aria-label', 'Close draw count selection');
+    closeButton.textContent = 'x';
+
+    header.append(title, closeButton);
+
+    const body = document.createElement('div');
+    body.className = 'draw-count-stats-body';
+
+    const lsrTotal = document.createElement('div');
+    const lsrTypes = document.createElement('div');
+    const sbwTotal = document.createElement('div');
+    const sbwTypes = document.createElement('div');
+
+    lsrTotal.className = 'draw-count-stats-line';
+    lsrTypes.className = 'draw-count-stats-line draw-count-stats-types';
+    sbwTotal.className = 'draw-count-stats-line';
+    sbwTypes.className = 'draw-count-stats-line draw-count-stats-types';
+
+    [lsrTotal, lsrTypes, sbwTotal, sbwTypes].forEach((row) => {
+        const label = document.createElement('span');
+        const value = document.createElement('span');
+        label.className = 'draw-count-stats-badge draw-count-stats-label';
+        value.className = 'draw-count-stats-values';
+        row.append(label, value);
+    });
+
+    body.append(lsrTotal, lsrTypes, sbwTotal, sbwTypes);
+    wrapper.append(header, body);
+
+    return {
+        element: wrapper,
+        header,
+        title,
+        closeButton,
+        lsrTotal,
+        lsrTypes,
+        sbwTotal,
+        sbwTypes
+    };
+}
+
+function makeStatsElementDraggable(statsElements) {
+    let dragState = null;
+
+    const stopDragging = () => {
+        dragState = null;
+        statsElements.element.classList.remove('dragging');
+        document.removeEventListener('mousemove', handleDrag);
+        document.removeEventListener('mouseup', stopDragging);
+    };
+
+    const handleDrag = (event) => {
+        if (!dragState) {
+            return;
+        }
+
+        const nextLeft = dragState.startLeft + (event.clientX - dragState.startX);
+        const nextTop = dragState.startTop + (event.clientY - dragState.startY);
+        statsElements.element.style.left = `${Math.max(10, nextLeft)}px`;
+        statsElements.element.style.top = `${Math.max(10, nextTop)}px`;
+    };
+
+    statsElements.header.addEventListener('mousedown', (event) => {
+        if (event.target === statsElements.closeButton) {
+            return;
+        }
+
+        event.preventDefault();
+        const rect = statsElements.element.getBoundingClientRect();
+        dragState = {
+            startX: event.clientX,
+            startY: event.clientY,
+            startLeft: rect.left,
+            startTop: rect.top
+        };
+        statsElements.element.classList.add('dragging');
+        document.addEventListener('mousemove', handleDrag);
+        document.addEventListener('mouseup', stopDragging);
+    });
+}
+
+function formatSelectionTitle(extent) {
+    if (!extent || extent.length < 4) {
+        return 'Selection Counts';
+    }
+
+    const geographicExtent = transformExtent(extent, 'EPSG:3857', 'EPSG:4326');
+    const [west, south, east, north] = geographicExtent;
+    const formatCoordinate = (value) => Number(value).toFixed(2);
+
+    return `Selection Counts within: ${formatCoordinate(west)} ${formatCoordinate(south)} ${formatCoordinate(east)} ${formatCoordinate(north)}`;
+}
+
+function updateStatsText(statsElements, summary) {
+    const setTotalRowText = (rowElement, labelText, valueText) => {
+        const labelElement = rowElement.children[0];
+        const valueElement = rowElement.children[1];
+        if (labelElement) {
+            labelElement.textContent = labelText;
+        }
+        if (valueElement) {
+            valueElement.replaceChildren();
+            const badge = document.createElement('span');
+            badge.className = 'draw-count-stats-badge draw-count-stats-value';
+            badge.textContent = valueText;
+            valueElement.appendChild(badge);
+        }
+    };
+
+    const setTypeRowText = (rowElement, labelText, typeCounts) => {
+        rowElement.replaceChildren();
+
+        const labelBadge = document.createElement('span');
+        labelBadge.className = 'draw-count-stats-badge draw-count-stats-label';
+        labelBadge.textContent = labelText;
+        rowElement.appendChild(labelBadge);
+
+        const entries = formatTypeCounts(typeCounts);
+        if (entries.length === 0) {
+            const badge = document.createElement('span');
+            badge.className = 'draw-count-stats-badge draw-count-stats-value';
+            badge.textContent = formatTypeCountText(typeCounts);
+            rowElement.appendChild(badge);
+            return;
+        }
+
+        entries.forEach(([type, count]) => {
+            const badge = document.createElement('span');
+            badge.className = 'draw-count-stats-badge draw-count-stats-value';
+            badge.textContent = `${type}: ${count}`;
+            rowElement.appendChild(badge);
+        });
+    };
+
+    setTotalRowText(statsElements.lsrTotal, 'LSR Total', String(summary.lsrTotal));
+    setTypeRowText(statsElements.lsrTypes, 'LSR Types', summary.lsrTypes);
+    setTotalRowText(statsElements.sbwTotal, 'Warning Total', String(summary.sbwTotal));
+    setTypeRowText(statsElements.sbwTypes, 'Warning Types', summary.sbwTypes);
+}
+
+function getLayerFeatures(layer) {
+    if (!layer || !layer.getSource) {
+        return [];
+    }
+    return layer.getSource()?.getFeatures?.() || [];
+}
+
+/**
+ * Initialize the draw-to-count rectangle tool.
+ * @param {import('ol/Map').default} map OpenLayers map instance
+ */
+export function initializeDrawCountTool(map) {
+    const mapTarget = map.getTargetElement();
+    if (!mapTarget) {
+        return;
+    }
+
+    const toggleButton = document.createElement('button');
+    toggleButton.type = 'button';
+    toggleButton.className = 'draw-count-toggle';
+    toggleButton.textContent = 'Draw to Count';
+    mapTarget.appendChild(toggleButton);
+
+    const statsElements = createStatsElement();
+    mapTarget.appendChild(statsElements.element);
+    makeStatsElementDraggable(statsElements);
+
+    const selectionLayer = makeSelectionLayer();
+    map.addLayer(selectionLayer);
+
+    const dragBox = new DragBox({
+        condition: always,
+        className: 'draw-count-dragbox'
+    });
+    dragBox.setActive(false);
+    map.addInteraction(dragBox);
+
+    let toolActive = false;
+    let currentExtent = null;
+
+    const clearSelection = () => {
+        currentExtent = null;
+        selectionLayer.getSource()?.clear();
+        statsElements.element.classList.remove('visible');
+    };
+
+    const drawSelection = (extent) => {
+        const geometry = fromExtent(extent);
+        const feature = new Feature({ geometry });
+        const source = selectionLayer.getSource();
+        source?.clear();
+        source?.addFeature(feature);
+    };
+
+    const positionStatsBox = (extent) => {
+        if (!extent) {
+            return;
+        }
+        const pixel = map.getPixelFromCoordinate([extent[0], extent[3]]);
+        if (!pixel) {
+            return;
+        }
+        const left = Math.max(10, pixel[0]);
+        const top = Math.max(10, pixel[1] - 8);
+        statsElements.element.style.left = `${left}px`;
+        statsElements.element.style.top = `${top}px`;
+    };
+
+    const refreshSummary = (extent) => {
+        const lsrLayer = getLSRLayer();
+        const sbwLayer = getSBWLayer();
+
+        const summary = summarizeDrawCounts(extent, {
+            lsrFeatures: getLayerFeatures(lsrLayer),
+            sbwFeatures: getLayerFeatures(sbwLayer),
+            lsrVisible: Boolean(lsrLayer?.getVisible?.()),
+            sbwVisible: Boolean(sbwLayer?.getVisible?.())
+        });
+
+        updateStatsText(statsElements, summary);
+        statsElements.title.textContent = formatSelectionTitle(extent);
+        positionStatsBox(extent);
+        statsElements.element.classList.add('visible');
+    };
+
+    const setToolActive = (nextActive) => {
+        toolActive = nextActive;
+        dragBox.setActive(nextActive);
+        toggleButton.classList.toggle('active', nextActive);
+        toggleButton.textContent = nextActive ? 'Stop Draw Count' : 'Draw to Count';
+        mapTarget.classList.toggle('draw-count-active', nextActive);
+    };
+
+    toggleButton.addEventListener('click', () => {
+        setToolActive(!toolActive);
+    });
+
+    statsElements.closeButton.addEventListener('click', () => {
+        setToolActive(false);
+        clearSelection();
+    });
+
+    dragBox.on('boxstart', () => {
+        clearSelection();
+    });
+
+    dragBox.on('boxdrag', () => {
+        const extent = dragBox.getGeometry()?.getExtent?.();
+        if (!extent) {
+            return;
+        }
+        currentExtent = extent.slice();
+        drawSelection(currentExtent);
+        refreshSummary(currentExtent);
+    });
+
+    dragBox.on('boxend', () => {
+        const extent = dragBox.getGeometry()?.getExtent?.();
+        if (!extent) {
+            clearSelection();
+            return;
+        }
+        currentExtent = extent.slice();
+        drawSelection(currentExtent);
+        refreshSummary(currentExtent);
+    });
+}

--- a/src/drawCountUtils.js
+++ b/src/drawCountUtils.js
@@ -1,0 +1,133 @@
+function isCoordinateInExtent(coordinate, extent) {
+    if (!Array.isArray(coordinate) || coordinate.length < 2 || !Array.isArray(extent) || extent.length < 4) {
+        return false;
+    }
+    const x = coordinate[0];
+    const y = coordinate[1];
+    return x >= extent[0] && x <= extent[2] && y >= extent[1] && y <= extent[3];
+}
+
+function isFeatureVisible(feature) {
+    return feature && feature.hidden !== true;
+}
+
+function featureIntersectsExtent(feature, extent) {
+    const geometry = feature?.getGeometry?.();
+    if (!geometry) {
+        return false;
+    }
+
+    if (typeof geometry.intersectsExtent === 'function') {
+        return geometry.intersectsExtent(extent);
+    }
+
+    if (typeof geometry.getCoordinates === 'function') {
+        return isCoordinateInExtent(geometry.getCoordinates(), extent);
+    }
+
+    return false;
+}
+
+function incrementTypeCount(typeCounts, typeKey) {
+    typeCounts[typeKey] = (typeCounts[typeKey] || 0) + 1;
+}
+
+function normalizeTypeKey(value) {
+    if (value === undefined || value === null || value === '') {
+        return 'UNK';
+    }
+    return String(value);
+}
+
+function getLSRTypeKey(feature) {
+    const lsrTypeText = feature?.get?.('typetext');
+    if (lsrTypeText !== undefined && lsrTypeText !== null && lsrTypeText !== '') {
+        return String(lsrTypeText);
+    }
+    return normalizeTypeKey(feature?.get?.('type'));
+}
+
+function getSBWTypeKey(feature) {
+    const phenomena = normalizeTypeKey(feature?.get?.('phenomena'));
+    const significance = normalizeTypeKey(feature?.get?.('significance'));
+    return `${phenomena}.${significance}`;
+}
+
+/**
+ * Summarize counts for LSR and SBW features intersecting an extent.
+ * @param {number[] | null} extent OpenLayers extent [minX, minY, maxX, maxY]
+ * @param {Object} options Counting options
+ * @param {Array} options.lsrFeatures LSR features to evaluate
+ * @param {Array} options.sbwFeatures SBW features to evaluate
+ * @param {boolean} options.lsrVisible Whether LSR layer is visible
+ * @param {boolean} options.sbwVisible Whether SBW layer is visible
+ * @returns {{lsrTotal:number,sbwTotal:number,lsrTypes:Object,sbwTypes:Object}}
+ */
+export function summarizeDrawCounts(
+    extent,
+    {
+        lsrFeatures = [],
+        sbwFeatures = [],
+        lsrVisible = true,
+        sbwVisible = true
+    } = {}
+) {
+    const summary = {
+        lsrTotal: 0,
+        sbwTotal: 0,
+        lsrTypes: {},
+        sbwTypes: {}
+    };
+
+    if (!Array.isArray(extent) || extent.length < 4) {
+        return summary;
+    }
+
+    if (lsrVisible) {
+        lsrFeatures.forEach((feature) => {
+            if (!isFeatureVisible(feature) || !featureIntersectsExtent(feature, extent)) {
+                return;
+            }
+            summary.lsrTotal += 1;
+            incrementTypeCount(summary.lsrTypes, getLSRTypeKey(feature));
+        });
+    }
+
+    if (sbwVisible) {
+        sbwFeatures.forEach((feature) => {
+            if (!isFeatureVisible(feature) || !featureIntersectsExtent(feature, extent)) {
+                return;
+            }
+            summary.sbwTotal += 1;
+            incrementTypeCount(summary.sbwTypes, getSBWTypeKey(feature));
+        });
+    }
+
+    return summary;
+}
+
+/**
+ * Format abbreviation-heavy type counts for compact UI display.
+ * @param {Object} typeCounts Map of type code to count
+ * @returns {string}
+ */
+export function formatTypeCounts(typeCounts) {
+    const entries = Object.entries(typeCounts || {});
+    entries.sort((a, b) => {
+        if (b[1] !== a[1]) {
+            return b[1] - a[1];
+        }
+        return a[0].localeCompare(b[0]);
+    });
+
+    return entries;
+}
+
+export function formatTypeCountText(typeCounts) {
+    const entries = formatTypeCounts(typeCounts);
+    if (entries.length === 0) {
+        return 'none';
+    }
+
+    return entries.map(([type, count]) => `${type}: ${count}`).join(' ');
+}

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,7 @@ import { startCronTasks } from './cronManager.js';
 import { initializeRightPane } from './rightPaneManager.js';
 import { initializeTabs } from './tabs.js';
 import { applySettings } from './settingsManager.js';
+import { initializeDrawCountTool } from './drawCountManager.js';
 
 function initializeApplication() {
     // First migrate any hash parameters to URL parameters
@@ -58,6 +59,7 @@ function initializeApplication() {
     olmap.addLayer(createLSRLayer("tfe", olmap));
 
     initializeLayerControls(olmap);
+    initializeDrawCountTool(olmap);
 
     // Apply URL-based settings after all layers and controls are initialized
     // This ensures settings from URL parameters are properly applied at page load

--- a/src/style.css
+++ b/src/style.css
@@ -2,6 +2,7 @@
 :root {
   --z-base: 1;
   --z-map: 10;
+  --z-map-tools: 30;
   --z-drawer: 100;
   --z-toggle: 101;
   --z-modal: 1000;
@@ -436,4 +437,124 @@ tr.shown td.details-control {
 #branding-overlay[data-mode="archive"] {
   background: rgba(255, 255, 224, 0.8);
   color: #8B8000;
+}
+
+.draw-count-toggle {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  z-index: var(--z-map-tools);
+  border: 1px solid #1f3c88;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.95);
+  color: #1f3c88;
+  font-weight: 700;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.draw-count-toggle.active {
+  background: #1f3c88;
+  color: #fff;
+}
+
+#map.draw-count-active .ol-viewport {
+  cursor: crosshair;
+}
+
+.draw-count-dragbox {
+  border: 2px dashed #0d47a1;
+  background-color: rgba(33, 150, 243, 0.15);
+}
+
+.draw-count-stats {
+  position: absolute;
+  z-index: var(--z-map-tools);
+  transform: translateY(-100%);
+  min-width: 230px;
+  max-width: 380px;
+  border: 1px solid #0d47a1;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.96);
+  color: #102a43;
+  font-family: "Open Sans", Arial, sans-serif;
+  font-size: 12px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.25);
+  display: none;
+}
+
+.draw-count-stats.visible {
+  display: block;
+}
+
+.draw-count-stats-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 8px;
+  background: #0d47a1;
+  color: #fff;
+  border-radius: 5px 5px 0 0;
+  font-weight: 700;
+  cursor: move;
+}
+
+.draw-count-stats-close {
+  border: none;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 2px 4px;
+}
+
+.draw-count-stats-body {
+  padding: 6px 8px;
+}
+
+.draw-count-stats.dragging {
+  user-select: none;
+}
+
+.draw-count-stats-line {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 5px;
+}
+
+.draw-count-stats-types {
+  gap: 4px;
+}
+
+.draw-count-stats-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  border-radius: 999px;
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+
+.draw-count-stats-label {
+  flex: 0 0 auto;
+  background: #dbeafe;
+  color: #0d47a1;
+  font-weight: 700;
+}
+
+.draw-count-stats-value {
+  background: #f0f4f8;
+  color: #102a43;
+}
+
+.draw-count-stats-values {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: 4px;
+  min-width: 0;
 }

--- a/tests/drawCountUtils.test.js
+++ b/tests/drawCountUtils.test.js
@@ -1,0 +1,126 @@
+import { describe, test, expect } from '@jest/globals';
+import { summarizeDrawCounts, formatTypeCounts, formatTypeCountText } from '../src/drawCountUtils.js';
+
+function makeFeature({
+    hidden = false,
+    intersects = false,
+    type,
+    typetext,
+    phenomena,
+    significance,
+    coordinate
+} = {}) {
+    return {
+        hidden,
+        get(key) {
+            if (key === 'type') {
+                return type;
+            }
+            if (key === 'typetext') {
+                return typetext;
+            }
+            if (key === 'phenomena') {
+                return phenomena;
+            }
+            if (key === 'significance') {
+                return significance;
+            }
+            return undefined;
+        },
+        getGeometry() {
+            return {
+                intersectsExtent() {
+                    return intersects;
+                },
+                getCoordinates() {
+                    return coordinate;
+                }
+            };
+        }
+    };
+}
+
+describe('drawCountUtils', () => {
+    test('summarizeDrawCounts respects visibility and hidden flags', () => {
+        const extent = [0, 0, 10, 10];
+        const lsrFeatures = [
+            makeFeature({ intersects: true, type: 'T', typetext: 'TORNADO' }),
+            makeFeature({ intersects: true, type: 'H', typetext: 'HAIL', hidden: true }),
+            makeFeature({ intersects: false, type: 'H', typetext: 'HAIL' })
+        ];
+        const sbwFeatures = [
+            makeFeature({ intersects: true, phenomena: 'TO', significance: 'W' }),
+            makeFeature({ intersects: true, phenomena: 'SV', significance: 'W' })
+        ];
+
+        const summary = summarizeDrawCounts(extent, {
+            lsrFeatures,
+            sbwFeatures,
+            lsrVisible: true,
+            sbwVisible: false
+        });
+
+        expect(summary.lsrTotal).toBe(1);
+        expect(summary.sbwTotal).toBe(0);
+        expect(summary.lsrTypes).toEqual({ TORNADO: 1 });
+        expect(summary.sbwTypes).toEqual({});
+    });
+
+    test('summarizeDrawCounts counts intersecting SBW types', () => {
+        const extent = [0, 0, 10, 10];
+        const summary = summarizeDrawCounts(extent, {
+            lsrFeatures: [],
+            sbwFeatures: [
+                makeFeature({ intersects: true, phenomena: 'TO', significance: 'W' }),
+                makeFeature({ intersects: true, phenomena: 'TO', significance: 'W' }),
+                makeFeature({ intersects: true, phenomena: 'SV', significance: 'W' }),
+                makeFeature({ intersects: false, phenomena: 'FF', significance: 'W' })
+            ],
+            lsrVisible: false,
+            sbwVisible: true
+        });
+
+        expect(summary.sbwTotal).toBe(3);
+        expect(summary.sbwTypes).toEqual({ 'TO.W': 2, 'SV.W': 1 });
+    });
+
+    test('summarizeDrawCounts falls back to coordinate checks when needed', () => {
+        const extent = [0, 0, 10, 10];
+        const feature = {
+            hidden: false,
+            get(key) {
+                if (key === 'typetext') {
+                    return 'TSTM WND GST';
+                }
+                return 'A';
+            },
+            getGeometry() {
+                return {
+                    getCoordinates() {
+                        return [5, 5];
+                    }
+                };
+            }
+        };
+
+        const summary = summarizeDrawCounts(extent, {
+            lsrFeatures: [feature],
+            sbwFeatures: [],
+            lsrVisible: true,
+            sbwVisible: false
+        });
+
+        expect(summary.lsrTotal).toBe(1);
+        expect(summary.lsrTypes).toEqual({ 'TSTM WND GST': 1 });
+    });
+
+    test('formatTypeCounts returns compact sorted output', () => {
+        expect(formatTypeCounts({ TO: 2, FF: 4, SV: 4 })).toEqual([
+            ['FF', 4],
+            ['SV', 4],
+            ['TO', 2]
+        ]);
+        expect(formatTypeCountText({ TO: 2, FF: 4, SV: 4 })).toBe('FF: 4 SV: 4 TO: 2');
+        expect(formatTypeCountText({})).toBe('none');
+    });
+});

--- a/tests/mocks/olMock.js
+++ b/tests/mocks/olMock.js
@@ -75,10 +75,20 @@ class MockGeoJSON {
     this.options = options;
   }
 }
+class MockDragBox {
+  constructor(options = {}) {
+    this.options = options;
+  }
+}
 
 // Mock functions
 const mockFromLonLat = () => [0, 0];
 const mockToLonLat = () => [0, 0];
+const mockTransformExtent = (extent) => extent;
+const mockFromExtent = (extent) => ({
+  extent,
+  getExtent: () => extent
+});
 
 const olMock = {
   Map: MockMap,
@@ -120,6 +130,7 @@ export const Feature = olMock.Feature;
 export const proj = olMock.proj;
 export const style = olMock.style;
 export const format = olMock.format;
+export const transformExtent = mockTransformExtent;
 
 // Export individual style components for direct imports
 export const Style = MockStyle;
@@ -133,3 +144,6 @@ export const Icon = MockIcon;
 export const GeoJSON = MockGeoJSON;
 export const VectorLayer = MockVectorLayer;
 export const VectorSource = MockVectorSource;
+export const DragBox = MockDragBox;
+export const always = () => true;
+export const fromExtent = mockFromExtent;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Draw to Count" feature enabling users to draw rectangles on the map to count intersecting weather warnings and local storm reports. The draggable statistics panel displays real-time counts organized by alert type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->